### PR TITLE
MySQL Database Setup Script

### DIFF
--- a/little_lemon_script.ipynb
+++ b/little_lemon_script.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "888cca2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mysql.connector as connector\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "6d9c3b26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    connection = connector.connect(\n",
+    "        user = \"root\",\n",
+    "        password = \"server@1234\",\n",
+    "    )\n",
+    "except connector.Error as er:\n",
+    "    print(\"error code :\", er.errno)\n",
+    "    print(\"error msg : \", er.msg)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2932c92d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor = connection.cursor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "08a09ccf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_db_query = \"\"\"SHOW DATABASES;\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "04e7b22d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "use_db_query = \"\"\"USE litlle_lemon;\"\"\"\n",
+    "create_db_query = \"\"\"CREATE DATABASE litlle_lemon;\"\"\"\n",
+    "create_table_query = \"\"\"\n",
+    "    create table MenuItems(\n",
+    "    ItemID INT AUTO_INCREMENT,\n",
+    "    NAME VARCHAR(500),\n",
+    "    TYPE VARCHAR(50),\n",
+    "    PRICE INT,\n",
+    "    PRIMARY KEY(ItemID)    \n",
+    "    );\n",
+    "\"\"\"\n",
+    "\n",
+    "create_menu_table = \"\"\"CREATE TABLE Menus (\n",
+    "MenuID INT,\n",
+    "ItemID INT,\n",
+    "Cuisine VARCHAR(100),\n",
+    "PRIMARY KEY (MenuID,ItemID)\n",
+    ");\"\"\"\n",
+    "\n",
+    "Create_booking_table = \"\"\"CREATE TABLE Bookings (\n",
+    "BookingID INT AUTO_INCREMENT,\n",
+    "TableNo INT,\n",
+    "GuestFirstName VARCHAR(100) NOT NULL,\n",
+    "GuestLastName VARCHAR(100) NOT NULL,\n",
+    "BookingSlot TIME NOT NULL,\n",
+    "EmployeeID INT,\n",
+    "PRIMARY KEY (BookingID)\n",
+    ");\"\"\"\n",
+    "\n",
+    "create_orders_table = \"\"\"CREATE TABLE Orders (\n",
+    "OrderID INT,\n",
+    "TableNo INT,\n",
+    "MenuID INT,\n",
+    "BookingID INT,\n",
+    "BillAmount INT,\n",
+    "Quantity INT,\n",
+    "PRIMARY KEY (OrderID,TableNo)\n",
+    ");\"\"\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "0a512143",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CREATE TABLE Orders (\n",
+      "OrderID INT,\n",
+      "TableNo INT,\n",
+      "MenuID INT,\n",
+      "BookingID INT,\n",
+      "BillAmount INT,\n",
+      "Quantity INT,\n",
+      "PRIMARY KEY (OrderID,TableNo)\n",
+      ");\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(create_orders_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "9fd08064",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "tdata = cursor.execute(\"show tables;\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "5c31aefb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(tdata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "adcda63d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('menuitems',)\n",
+      "('menus',)\n",
+      "('orders',)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for tables in cursor:\n",
+    "    print(tables)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "52a0709b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tdata = cursor.execute(\"select * from menus\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "90c5851f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "t2data = cursor.execute(\"select * from orders\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "92891149",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(create_db_query)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "60f92c41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(use_db_query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "dec50558",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(create_table_query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "6702fcef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(create_menu_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "261bb7b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(Create_booking_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "8a44f0a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cursor.execute(create_orders_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "8093fa3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cursor.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "b92a2a62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af75a98e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f9d81f0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (133686754.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;36m  Cell \u001b[1;32mIn[9], line 1\u001b[1;36m\u001b[0m\n\u001b[1;33m    cursor.execute(select * from Orders)\u001b[0m\n\u001b[1;37m                            ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "cursor.execute(select * from Orders)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adb71658",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This Python script demonstrates how to set up a MySQL database for a restaurant management system. It connects to a MySQL database server using the `mysql.connector` module, creates a new database named "little_lemon," and sets up tables for managing menu items, menus, bookings, and orders within the database.

The script performs the following steps:
- Establishes a connection to the MySQL server using the provided credentials.
- Defines SQL queries for creating the necessary tables: `MenuItems`, `Menus`, `Bookings`, and `Orders`.
- Executes the SQL queries to create the database and tables.
- Demonstrates checking for existing tables using `SHOW TABLES` query and printing the results.
- Uses sample SQL queries to retrieve data from non-existing tables (just for illustration).

Please note that you need to replace placeholders like `your_host`, `user`, and `password` with actual MySQL server information. Additionally, consider modifying the table structures and data types to suit your application's requirements.

Feel free to modify and adapt this script for your specific use case. It can serve as a starting point for setting up the database backend of a restaurant management application.